### PR TITLE
Allow nav.expanded to scroll

### DIFF
--- a/teehan_lax_navigation/style.css
+++ b/teehan_lax_navigation/style.css
@@ -190,6 +190,7 @@ nav.expanded {
   position: fixed;
   cursor: default;
   background: rgba(255,255,255,.85);
+  overflow-y: scroll;
 }
 
 /* positions navigation content */


### PR DESCRIPTION
On the demo page the content of the popover menu is longer than the page so it's cut off at the bottom.

Added overflow-y: scroll to the expanded nav class to allow it to scroll.
